### PR TITLE
Fix screenInfo availability issue

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,10 +44,7 @@ class _ScreenInfoDisplayState extends State<ScreenInfoDisplay> {
   @override
   Widget build(BuildContext context) {
     // Access screen information using ScreenInfo.of(context)
-    final screenInfo = ScreenInfo.maybeOf(context);
-    if (screenInfo == null) {
-      return const CircularProgressIndicator();
-    }
+    final screenInfo = ScreenInfo.of(context);
 
     // Use the extension method to convert mm to pixels
     final lineLengthInPixels = context.mmToPx(_lineLengthMm);


### PR DESCRIPTION
Fixes #3

Add a `FutureBuilder` to `ScreenHelperWidget` to wait for `screenInfoData` to be available.

* Modify `_fetchAndSetScreenInfo` to return a `Future` in `lib/screen_helper_widget.dart`.
* Update `build` method in `lib/screen_helper_widget.dart` to use `FutureBuilder` to wait for `screenInfoData`.
* Remove the null check for `screenInfo` in `ScreenInfoDisplay` in `example/lib/main.dart`.
* Remove the `CircularProgressIndicator` in `ScreenInfoDisplay` in `example/lib/main.dart`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TOZXII/screen_helper/issues/3?shareId=cf6b76bb-40b1-4d4b-944f-3fbc9968b3cf).